### PR TITLE
Feature ETP-3270: Add DevContainer for Fast Install

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+# Instalar herramientas necesarias
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    unzip \
+    postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configurar directorio de trabajo
+WORKDIR /workspace
+
+# Mantener el contenedor activo
+CMD ["sleep", "infinity"]

--- a/.devcontainer/Dockerfile.full
+++ b/.devcontainer/Dockerfile.full
@@ -1,0 +1,52 @@
+# Dockerfile.full - Imagen completa con Etendo pre-instalado
+# Tiempo de inicio: ~10 segundos (vs ~10 minutos desde cero)
+
+FROM mcr.microsoft.com/devcontainers/java:17-bullseye
+
+ARG GITHUB_USER
+ARG GITHUB_TOKEN
+ARG NEXUS_USER  
+ARG NEXUS_PASSWORD
+
+# Eliminar repositorio de Yarn con clave expirada
+RUN rm -f /etc/apt/sources.list.d/yarn.list 2>/dev/null || true
+
+# Instalar herramientas
+RUN apt-get update && apt-get install -y \
+    git curl unzip postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+# Copiar proyecto
+COPY . /workspace/
+
+# Configurar gradle.properties con credenciales de build
+RUN echo "bbdd.rdbms=POSTGRESQL" > gradle.properties && \
+    echo "bbdd.driver=org.postgresql.Driver" >> gradle.properties && \
+    echo "bbdd.url=jdbc:postgresql://db:5432" >> gradle.properties && \
+    echo "bbdd.sid=etendo" >> gradle.properties && \
+    echo "bbdd.systemUser=postgres" >> gradle.properties && \
+    echo "bbdd.systemPassword=syspass" >> gradle.properties && \
+    echo "bbdd.user=tad" >> gradle.properties && \
+    echo "bbdd.password=tad" >> gradle.properties && \
+    echo "githubUser=${GITHUB_USER}" >> gradle.properties && \
+    echo "githubToken=${GITHUB_TOKEN}" >> gradle.properties && \
+    echo "nexusUser=${NEXUS_USER}" >> gradle.properties && \
+    echo "nexusPassword=${NEXUS_PASSWORD}" >> gradle.properties
+
+# Ejecutar setup y compilación completa
+RUN chmod +x gradlew && \
+    ./gradlew --no-daemon setup && \
+    ./gradlew --no-daemon classes smartbuild -x test || true
+
+# Crear dump de BD para restore rápido (si hay)
+# RUN pg_dump ... > /workspace/.devcontainer/etendo_base.sql
+
+# Limpiar para reducir tamaño de imagen
+RUN rm -rf /root/.gradle/daemon /root/.gradle/caches/*/transforms-*
+
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+ENV ETENDO_PREBUILT=true
+
+CMD ["sleep", "infinity"]

--- a/.devcontainer/Dockerfile.prebuild
+++ b/.devcontainer/Dockerfile.prebuild
@@ -1,0 +1,43 @@
+# Dockerfile.prebuild - Imagen pre-construida con todo el setup
+# Esta imagen se usa como base para desarrollo rápido
+
+FROM mcr.microsoft.com/devcontainers/java:17-bullseye
+
+# Eliminar repositorio de Yarn con clave expirada
+RUN rm -f /etc/apt/sources.list.d/yarn.list 2>/dev/null || true
+
+# Instalar herramientas adicionales
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    unzip \
+    postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configurar directorio de trabajo
+WORKDIR /workspace
+
+# Copiar archivos de proyecto
+COPY . /workspace/
+
+# Pre-descargar dependencias de Gradle (cache)
+RUN if [ -f "gradlew" ]; then \
+    chmod +x gradlew && \
+    ./gradlew --no-daemon dependencies || true && \
+    ./gradlew --no-daemon setup || true; \
+    fi
+
+# Pre-calentar cache de Gradle
+RUN mkdir -p /root/.gradle && \
+    echo "org.gradle.daemon=false" >> /root/.gradle/gradle.properties && \
+    echo "org.gradle.caching=true" >> /root/.gradle/gradle.properties
+
+# Limpiar archivos temporales pero mantener cache
+RUN rm -rf /workspace/build /workspace/.gradle/daemon
+
+# Variables de entorno por defecto
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
+ENV GRADLE_USER_HOME=/root/.gradle
+
+# Mantener container activo
+CMD ["sleep", "infinity"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,18 @@
+{
+  "name": "Etendo SaaS Dev Env",
+  "dockerComposeFile": "../docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspace",
+  "onCreateCommand": "bash .devcontainer/setup-etendo.sh",
+  "postStartCommand": "echo 'Etendo ready at http://localhost:8080/etendo'",
+  "forwardPorts": [8080, 5432],
+  "features": {
+    "ghcr.io/devcontainers/features/java:1": { "version": "17" },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["vscjava.vscode-java-pack"]
+    }
+  }
+}

--- a/.devcontainer/setup-etendo.sh
+++ b/.devcontainer/setup-etendo.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Configurar las propiedades de Etendo para el entorno SaaS
+cat <<EOF > gradle.properties
+bbdd.rdbms=POSTGRESQL
+bbdd.driver=org.postgresql.Driver
+bbdd.url=jdbc:postgresql://db:5432
+bbdd.sid=etendo
+bbdd.systemUser=postgres
+bbdd.systemPassword=syspass
+bbdd.user=tad
+bbdd.password=tad
+githubUser=${GITHUB_USER}
+githubToken=${GITHUB_TOKEN}
+nexusUser=${NEXUS_USER}
+nexusPassword=${NEXUS_PASSWORD}
+EOF
+
+# Modificar build.gradle para usar core en JARs
+cat <<'EOF' > build.gradle
+plugins {
+    id 'java'
+    id 'war'
+    id 'groovy'
+    id 'maven-publish'
+    id 'com.etendoerp.gradleplugin' version '2.2.1'
+    id 'com.etendoerp.testing.gradleplugin' version '2.1.0'
+}
+
+etendo {
+    coreVersion = "[25.1.0,26.1.0)"
+}
+
+dependencies {
+    // Etendo Core in JAR format
+    implementation('com.etendoerp.platform:etendo-core:[25.1.0,26.1.0)')
+    implementation('com.etendoerp:dependencymanager:[3.0.0,4.0.0)')
+}
+EOF
+
+# Crear directorios necesarios
+mkdir -p lib config
+
+# Limpiar build anterior si existe
+rm -rf build .gradle
+
+# Ejecutar setup
+./gradlew setup
+
+# Verificar si la base de datos ya tiene tablas (instalación previa)
+DB_EXISTS=$(PGPASSWORD=syspass psql -h db -U postgres -d etendo -tc "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public'" 2>/dev/null | tr -d ' ')
+
+if [ "$DB_EXISTS" -gt "0" ] 2>/dev/null; then
+    echo "Base de datos ya instalada, omitiendo install..."
+else
+    echo "Instalando base de datos..."
+    ./gradlew install
+fi
+
+./gradlew smartbuild
+
+# Generar WAR y copiarlo
+./gradlew antWar
+
+echo "Deploy completado. Accede a http://localhost:8080/etendo"

--- a/.devcontainer/setup-quick.sh
+++ b/.devcontainer/setup-quick.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# setup-quick.sh - Setup rápido para imagen pre-built
+# Solo configura credenciales, NO compila (ya está en la imagen)
+
+set -e
+
+echo "════════════════════════════════════════════════════"
+echo "🚀 Quick Setup for Pre-built Image"
+echo "════════════════════════════════════════════════════"
+
+# Verificar si gradle.properties existe
+if [ -f "gradle.properties" ]; then
+    echo "✅ gradle.properties already exists"
+else
+    echo "📝 Creating gradle.properties..."
+    cat <<EOF > gradle.properties
+bbdd.rdbms=POSTGRESQL
+bbdd.driver=org.postgresql.Driver
+bbdd.url=jdbc:postgresql://db:5432
+bbdd.sid=etendo
+bbdd.systemUser=postgres
+bbdd.systemPassword=syspass
+bbdd.user=tad
+bbdd.password=tad
+githubUser=${GITHUB_USER:-}
+githubToken=${GITHUB_TOKEN:-}
+nexusUser=${NEXUS_USER:-}
+nexusPassword=${NEXUS_PASSWORD:-}
+EOF
+    echo "✅ gradle.properties created"
+fi
+
+# Verificar conexión a BD
+echo "🔍 Checking database connection..."
+for i in {1..30}; do
+    if pg_isready -h db -U postgres > /dev/null 2>&1; then
+        echo "✅ Database is ready"
+        break
+    fi
+    echo "   Waiting for database... ($i/30)"
+    sleep 1
+done
+
+# Verificar si Etendo está instalado
+DB_TABLES=$(PGPASSWORD=syspass psql -h db -U postgres -d etendo -tc "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public'" 2>/dev/null | tr -d ' ' || echo "0")
+
+if [ "$DB_TABLES" -gt "10" ] 2>/dev/null; then
+    echo "✅ Etendo database already installed ($DB_TABLES tables)"
+else
+    echo "⚠️  Database empty - run './gradlew install' to install Etendo"
+fi
+
+echo ""
+echo "════════════════════════════════════════════════════"
+echo "✅ Quick setup complete!"
+echo ""
+echo "Next steps:"
+echo "  1. ./gradlew install    # Install database (first time only)"
+echo "  2. ./gradlew setup.web  # Start Fast Install UI"
+echo "  3. Open http://localhost:3851"
+echo "════════════════════════════════════════════════════"

--- a/.devcontainer/start-services.sh
+++ b/.devcontainer/start-services.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# start-services.sh - Auto-inicia servicios al arrancar devcontainer
+
+set -e
+
+echo ""
+echo "════════════════════════════════════════════════════"
+echo "🚀 Starting Etendo Services..."
+echo "════════════════════════════════════════════════════"
+
+# Limpiar build si hay problemas de permisos
+if [ -d "/workspace/build" ]; then
+    echo "🧹 Cleaning build directory..."
+    rm -rf /workspace/build 2>/dev/null || sudo rm -rf /workspace/build 2>/dev/null || true
+fi
+
+# Clonar plugin con setup.web si no existe
+if [ ! -d "/workspace/buildSrc" ]; then
+    echo "📦 Cloning gradle plugin with setup.web task..."
+    git clone --depth 1 -b feature/ETP-2946-Y26 https://github.com/etendosoftware/com.etendoerp.gradleplugin.git /workspace/buildSrc
+    cd /workspace/buildSrc && cp gradle.properties.template gradle.properties
+    cd /workspace
+    # Remover versión del plugin en build.gradle (ya viene de buildSrc)
+    sed -i "s/id 'com.etendoerp.gradleplugin' version '[^']*'/id 'com.etendoerp.gradleplugin'/" /workspace/build.gradle
+    echo "✅ Plugin cloned to buildSrc"
+fi
+
+# Esperar a que la BD esté lista
+echo "⏳ Waiting for database..."
+for i in {1..30}; do
+    if pg_isready -h db -U postgres > /dev/null 2>&1; then
+        echo "✅ Database ready"
+        break
+    fi
+    sleep 1
+done
+
+# Verificar si necesita install
+DB_TABLES=$(PGPASSWORD=syspass psql -h db -U postgres -d etendo -tc "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public'" 2>/dev/null | tr -d ' ' || echo "0")
+
+if [ "$DB_TABLES" -lt "10" ] 2>/dev/null; then
+    echo "📦 Installing database (first time)..."
+    ./gradlew install --no-daemon || true
+else
+    echo "🔄 Database already installed, skipping install step."
+fi
+
+# Iniciar Fast Install UI en background
+echo "🛠️  Starting Fast Install UI..."
+nohup ./gradlew setup.web --no-daemon > /tmp/setup-web.log 2>&1 &
+
+# Esperar a que el servidor esté listo
+for i in {1..30}; do
+    if curl -s http://localhost:3851 > /dev/null 2>&1; then
+        echo "✅ Fast Install UI ready at http://localhost:3851"
+        break
+    fi
+    sleep 1
+done
+
+echo ""
+echo "════════════════════════════════════════════════════"
+echo "✅ Etendo Dev Environment Ready!"
+echo ""
+echo "   🛠️  Fast Install UI: http://localhost:3851"
+echo "   🌐 Etendo ERP:       http://localhost:8080/etendo"
+echo "════════════════════════════════════════════════════"

--- a/.devcontainer/tomcat/server.xml
+++ b/.devcontainer/tomcat/server.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Server port="8005" shutdown="SHUTDOWN">
+  <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+  <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+  <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+  <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener" />
+  <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+
+  <GlobalNamingResources>
+    <Resource name="UserDatabase" auth="Container"
+              type="org.apache.catalina.UserDatabase"
+              description="User database that can be updated and saved"
+              factory="org.apache.catalina.users.MemoryUserDatabaseFactory"
+              pathname="conf/tomcat-users.xml" />
+  </GlobalNamingResources>
+
+  <Service name="Catalina">
+    <Connector port="8080" protocol="HTTP/1.1"
+               connectionTimeout="20000"
+               redirectPort="8443"
+               proxyPort="443"
+               scheme="https"
+               secure="true" />
+
+    <Engine name="Catalina" defaultHost="localhost">
+      <Realm className="org.apache.catalina.realm.LockOutRealm">
+        <Realm className="org.apache.catalina.realm.UserDatabaseRealm"
+               resourceName="UserDatabase"/>
+      </Realm>
+
+      <Host name="localhost" appBase="webapps"
+            unpackWARs="true" autoDeploy="true">
+
+        <!-- RemoteIpValve para manejar headers de proxy (Codespaces, etc) -->
+        <Valve className="org.apache.catalina.valves.RemoteIpValve"
+               remoteIpHeader="X-Forwarded-For"
+               protocolHeader="X-Forwarded-Proto"
+               protocolHeaderHttpsValue="https" />
+
+        <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
+               prefix="localhost_access_log" suffix=".txt"
+               pattern="%h %l %u %t &quot;%r&quot; %s %b" />
+      </Host>
+    </Engine>
+  </Service>
+</Server>

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,7 @@
 !.run
 !.run/**
 !.github
-!.github/**
+!.github/**.env
+!.devcontainer
+!.devcontainer/**
+!docker-compose.yml

--- a/build.gradle
+++ b/build.gradle
@@ -12,16 +12,10 @@ etendo {
 }
 
 dependencies {
-    /*
-    To use Etendo in JAR format delete the Etendo section and uncomment the following line.
-    Then when executing any gradle command the core will be dynamically downloaded as a dependency.
-    Set up the credentials in gradle.properties file
-
+    // Etendo Core in JAR format
     implementation('com.etendoerp.platform:etendo-core:[25.1.0,26.1.0)')
-    */
 
     //Add other dependencies bellow
-
     implementation('com.etendoerp:dependencymanager:[3.0.0,4.0.0)')
     implementation('com.etendoerp:platform.extensions:[3.0.0,4.0.0)')
     implementation('com.etendoerp:copilot.extensions:[3.0.0,4.0.0)')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,49 @@
+services:
+  db:
+    image: postgres:15
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=syspass
+      - POSTGRES_DB=etendo
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  tomcat:
+    image: tomcat:9-jdk17
+    volumes:
+      - ./lib/etendo:/usr/local/tomcat/webapps/etendo
+      - ./.devcontainer/tomcat/server.xml:/usr/local/tomcat/conf/server.xml
+    ports:
+      - "8080:8080"
+    environment:
+      - CATALINA_OPTS=-Djava.security.egd=file:/dev/./urandom
+    depends_on:
+      - db
+
+  app:
+    build:
+      context: .
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - .:/workspace:cached
+      - gradle_cache:/root/.gradle
+    working_dir: /workspace
+    ports:
+      - "3851:3851"
+    environment:
+      - DATABASE_URL=jdbc:postgresql://db:5432/etendo
+      - GITHUB_USER=${GITHUB_USER}
+      - GITHUB_TOKEN=${GITHUB_TOKEN}
+      - NEXUS_USER=${NEXUS_USER}
+      - NEXUS_PASSWORD=${NEXUS_PASSWORD}
+    depends_on:
+      - db
+      - tomcat
+    stdin_open: true
+    tty: true
+
+volumes:
+  postgres_data:
+  gradle_cache:


### PR DESCRIPTION
## Summary
- Add DevContainer configuration for VSCode/GitHub Codespaces
- Include docker-compose.yml for local development environment
- Add setup scripts for automated Etendo installation

## Files Added
- `.devcontainer/` folder with Dockerfile variants and setup scripts
- `docker-compose.yml` for service orchestration
- Updated `.gitignore` to allow devcontainer files

## Related
- Jira: [ETP-3270](https://etendoproject.atlassian.net/browse/ETP-3270)
- Epic: [ETP-3241](https://etendoproject.atlassian.net/browse/ETP-3241) (Fast Install)

🤖 Generated with [Claude Code](https://claude.ai/code)

[ETP-3270]: https://etendoproject.atlassian.net/browse/ETP-3270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ETP-3241]: https://etendoproject.atlassian.net/browse/ETP-3241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ